### PR TITLE
Add kustomize example, latest tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,4 +31,7 @@ jobs:
         env:
           # Only populate tag on a release
           IMAGE_TAG: "${{ github.event_name == 'release' && github.ref_name || '' }}"
+          # Populate latest tag on main branch
+          IMAGE_LATEST: "${{ github.ref_name == 'main' && 'latest' || '' }}"
+          # Populate sha tag on every push
           IMAGE_SHA: "${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
+.configmap.env
+.ingress.yaml
 .venv

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,10 @@
 export IMAGE_LATEST := "latest"
 export IMAGE_SHA := `git rev-parse HEAD | cut -c-12`
 
+CF_ISSUER_URL := env_var_or_default("CF_ISSUER_URL", "https://example.cloudflareaccess.com")
+CF_AUDIENCE_TAG := env_var_or_default("CF_AUDIENCE_TAG", "example-audience")
+INGRESS_HOST := env_var_or_default("INGRESS_HOST", "echo-sidecar.example.com")
+
 # List targets (local)
 help:
 	@just --list --unsorted
@@ -16,8 +20,29 @@ check:
 	golangci-lint run
 
 	pushd examples/echo_server
-	gofmt -s -w .
-	golangci-lint run
+	gofmt -s -w . && golangci-lint run
+	popd
+
+kustomize:
+	#!/bin/bash
+	set -euxo pipefail
+	cd examples/echo_sidecar
+
+	cat <<EOF >.env
+	CF_ISSUER_URL={{CF_ISSUER_URL}}
+	CF_AUDIENCE_TAG={{CF_AUDIENCE_TAG}}
+	EOF
+
+	cat <<EOF >.ingress.yaml
+	- op: replace
+	  path: /spec/rules/0/host
+	  value: {{INGRESS_HOST}}
+	- op: replace
+	  path: /spec/tls/0/hosts/0
+	  value: {{INGRESS_HOST}}
+	EOF
+
+	kustomize build .
 
 # Build and run the Go application
 run:

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-export IMAGE_TAG := env_var_or_default("IMAGE_TAG", "latest")
+export IMAGE_LATEST := "latest"
 export IMAGE_SHA := `git rev-parse HEAD | cut -c-12`
 
 # List targets (local)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,6 +3,7 @@ variable "IMAGE_REPO" {
 }
 variable "IMAGE_SHA" {}
 variable "IMAGE_TAG" {}
+variable "IMAGE_LATEST" {}
 
 group "default" {
   targets = ["goflarecar", "echo-example"]
@@ -13,7 +14,7 @@ target "goflarecar" {
   tags = [
     "${IMAGE_REPO}:${IMAGE_SHA}",
     equal("${IMAGE_TAG}", "") ? "" : "${IMAGE_REPO}:${IMAGE_TAG}",
-    equal("${IMAGE_TAG}", "main") ? "${IMAGE_REPO}:latest" : "",
+    equal("${IMAGE_LATEST}", "latest") ? "${IMAGE_REPO}:latest" : "",
   ]
 }
 
@@ -24,6 +25,6 @@ target "echo-example" {
   tags = [
     "${IMAGE_REPO}-echo:${IMAGE_SHA}",
     equal("${IMAGE_TAG}", "") ? "" : "${IMAGE_REPO}-echo:${IMAGE_TAG}",
-    equal("${IMAGE_TAG}", "main") ? "${IMAGE_REPO}-echo:latest" : "",
+    equal("${IMAGE_LATEST}", "latest") ? "${IMAGE_REPO}-echo:latest" : "",
   ]
 }

--- a/examples/echo_sidecar/deployment.yaml
+++ b/examples/echo_sidecar/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-sidecar
+  labels:
+    app.kubernetes.io/name: echo-sidecar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: echo-sidecar
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: echo-sidecar
+    spec:
+      containers:
+        - name: echo
+          image: ghcr.io/parente/goflarecar-echo:latest
+          imagePullPolicy: Always
+        - name: goflarecar
+          image: ghcr.io/parente/goflarecar:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: proxy-port
+          env:
+            - name: UPSTREAM_APP_URL
+              value: "http://127.0.0.1:8081"
+            - name: PROXY_PASS_JSON_CLAIMS
+              value: "yes"
+          envFrom:
+            - configMapRef:
+                name: echo-sidecar

--- a/examples/echo_sidecar/ingress.yaml
+++ b/examples/echo_sidecar/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: echo-sidecar
+  labels:
+    app.kubernetes.io/name: echo-sidecar
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - placeholder # To be replaced by a kustomize patch
+      secretName: echo-sidecar-some-domain-tls
+  rules:
+    - host: placeholder # To be replaced by a kustomize patch
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: echo-sidecar
+                port:
+                  name: http

--- a/examples/echo_sidecar/kustomization.yaml
+++ b/examples/echo_sidecar/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+
+configMapGenerator:
+  - name: echo-sidecar
+    envs:
+      - .configmap.env
+
+patches:
+  - target:
+      kind: Ingress
+      name: echo-sidecar
+    path: .ingress.yaml

--- a/examples/echo_sidecar/service.yaml
+++ b/examples/echo_sidecar/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-sidecar
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: echo-sidecar
+  ports:
+    - name: http
+      port: 80
+      targetPort: proxy-port


### PR DESCRIPTION
This pull request introduces several changes to enhance Docker image tagging, streamline Kubernetes deployment configuration, and improve development workflows. The most notable updates include adding support for an `IMAGE_LATEST` tag, creating Kubernetes manifests for the `echo-sidecar` application, and refining the `Justfile` for better usability.

### Docker Image Tagging Enhancements:
* Added `IMAGE_LATEST` environment variable in `.github/workflows/build.yaml` to tag images as `latest` on the main branch. Updated `docker-bake.hcl` to use `IMAGE_LATEST` for tagging logic. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R34-R36) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R6) [[3]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L16-R17) [[4]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L27-R28)

### Kubernetes Deployment Configuration:
* Added `deployment.yaml`, `service.yaml`, and `ingress.yaml` files for the `echo-sidecar` application, defining deployment, service, and ingress resources, respectively. [[1]](diffhunk://#diff-20877006404e1a8c51fd32170eaec8fbd78ea80af21ec12f6bd40286b4b00ec9R1-R34) [[2]](diffhunk://#diff-5096c8664a262023a1c34f855ac6b28a6c44cb77e6483c4e72a393dd7a5aae72R1-R12) [[3]](diffhunk://#diff-da2a6210786c43b5aff8eabf1c797dee3f0c792186315a82ae6901b25934356bR1-R25)
* Introduced `kustomization.yaml` to manage Kubernetes resources and patches for environment-specific configurations.

### Development Workflow Improvements:
* Refined `Justfile` by adding variables (`CF_ISSUER_URL`, `CF_AUDIENCE_TAG`, `INGRESS_HOST`) and a `kustomize` target for generating environment-specific Kubernetes configurations. [[1]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL1-R7) [[2]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL19-R45)