### PR TITLE
Fix CodeQL finding, director reference error

### DIFF
--- a/examples/echo_server/go.mod
+++ b/examples/echo_server/go.mod
@@ -1,4 +1,4 @@
-module github.com/parente/cloudflarecar/examples/echo_server
+module github.com/parente/goflarecar/examples/echo_server
 
 go 1.24.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/parente/cloudflarecar
+module github.com/parente/goflarecar
 
 go 1.26.0
 

--- a/main.go
+++ b/main.go
@@ -258,8 +258,8 @@ func main() {
 	go fetchJwksPeriodically(cfJwksURL, JWKS_REFRESH_INTERVAL)
 
 	// --- 3. Setup the Reverse Proxy for standard HTTP requests ---
-	// Create a new ReverseProxy instance.
-	rp := httputil.NewSingleHostReverseProxy(upstreamURL)
+	// Create a new ReverseProxy instance using only Rewrite (not Director).
+	rp := &httputil.ReverseProxy{}
 
 	// Use Rewrite to configure the outbound request.
 	rp.Rewrite = func(r *httputil.ProxyRequest) {


### PR DESCRIPTION
Address https://github.com/parente/goflarecar/security/code-scanning/1 in the echo server, an uncaught error after addressing a deprecation warning in #3, and a leftover legacy module name reference.